### PR TITLE
An option which can turn off xmp changing.

### DIFF
--- a/Common/Common.cpp
+++ b/Common/Common.cpp
@@ -241,6 +241,10 @@ void SetToolTip(HWND tt, string value) {
 }
 
 void SetSlider(HWND tt, int value) {
+	if (value == -1) {
+		SetToolTip(tt, string("OFF"));
+		return;
+	}
 	SetToolTip(tt, to_string(value));
 }
 

--- a/alienfan-tools/alienfan-SDK_v2/alienfan-SDK.cpp
+++ b/alienfan-tools/alienfan-SDK_v2/alienfan-SDK.cpp
@@ -318,6 +318,7 @@ namespace AlienFan_SDK {
 
 	int Control::SetXMP(byte memXMP)
 	{
+		if (memXMP == -1)return 0;//set a value to bypass Xmp function
 		if (isXMP) {
 			int res = CallWMIMethod(setXMP, memXMP);
 			return res ? -1 : res;

--- a/alienfan-tools/alienfan-gui/alienfan-gui.cpp
+++ b/alienfan-tools/alienfan-gui/alienfan-gui.cpp
@@ -199,7 +199,7 @@ LRESULT CALLBACK FanDialog(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam
         }
         EnableWindow(xmp_slider, mon->acpi->isXMP);
         if (mon->acpi->isXMP) {
-            SendMessage(xmp_slider, TBM_SETRANGE, true, MAKELPARAM(0, 2));
+            SendMessage(xmp_slider, TBM_SETRANGE, true, MAKELPARAM(-1, 2));
             sTip2 = CreateToolTip(xmp_slider, sTip2);
             SetSlider(sTip2, fan_conf->lastProf->memoryXMP);
             SendMessage(xmp_slider, TBM_SETPOS, true, fan_conf->lastProf->memoryXMP);

--- a/alienfan-tools/alienfan-shared/ConfigFan.cpp
+++ b/alienfan-tools/alienfan-shared/ConfigFan.cpp
@@ -38,7 +38,7 @@ void ConfigFan::Load() {
 	GetReg("StartMinimized", &startMinimized);
 	GetReg("UpdateCheck", &updateCheck, 1);
 	GetReg("LastPowerStage", &prof.powerSet);
-	GetReg("OC", &prof.ocSettings, 100);
+	GetReg("OC", &prof.ocSettings, (0xff << 8 | 100));
 	GetReg("DisableAWCC", &awcc_disable);
 	GetReg("KeyboardShortcut", &keyShortcuts, 1);
 	GetReg("KeepSystemMode", &keepSystem, 1);

--- a/alienfan-tools/alienfan-shared/ConfigFan.h
+++ b/alienfan-tools/alienfan-shared/ConfigFan.h
@@ -30,9 +30,9 @@ struct fan_profile {
 	union {
 		struct {
 			byte currentTCC;
-			byte memoryXMP;
+			signed char memoryXMP;
 		};
-		DWORD ocSettings = 100;
+		DWORD ocSettings = (0xff <<8|100);
 	};
 };
 

--- a/alienfx-gui/FanDialog.cpp
+++ b/alienfx-gui/FanDialog.cpp
@@ -71,7 +71,7 @@ BOOL CALLBACK TabFanDialog(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam
         }
         EnableWindow(xmp_slider, mon->acpi->isXMP);
         if (mon->acpi->isXMP) {
-            SendMessage(xmp_slider, TBM_SETRANGE, true, MAKELPARAM(0, 2));
+            SendMessage(xmp_slider, TBM_SETRANGE, true, MAKELPARAM(-1, 2));
             sTip2 = CreateToolTip(xmp_slider, sTip2);
             SetSlider(sTip2, fan_conf->lastProf->memoryXMP);
             SendMessage(xmp_slider, TBM_SETPOS, true, fan_conf->lastProf->memoryXMP);


### PR DESCRIPTION
My laptop is aw m16r1 which be allowed to overclock the RAM freq by using RU or UMAF by myself when dell updated the bios to 1.15 .And the RAM profile is "custom profile" rather than "default" or "XMP 1 or 2 or 3" after the overclocking.So,if there is no a function which can turn if off,it will reset my profile automatically. 