### PR TITLE
New 'nodisksensor' command 

### DIFF
--- a/Doc/alienfan-cli.md
+++ b/Doc/alienfan-cli.md
@@ -22,7 +22,8 @@ Available commands:
 - `gettcc` - Show current CPU TCC offset level.
 - `settcc=<value>` - Set CPU TCC offset to desired level (celsius degree).
 - `getxmp` - Show selected memory XMP profile (0 - disabled).
-- `setxmp` - Set memory XMP profile (0..2, 0 is disable)/
+- `setxmp` - Set memory XMP profile (0..2, 0 is disable).
+- `nodisksensor` - Do not query disk sensors (used to prevent alienfan-cli from freezing on some systems).
 - `dump` - List all available Alienware methods (it's useful for new devices support).
 
 In case you system have ACPI light control, 2 more commands available:

--- a/alienfan-tools/alienfan-SDK_v2/alienfan-SDK.cpp
+++ b/alienfan-tools/alienfan-SDK_v2/alienfan-SDK.cpp
@@ -212,7 +212,8 @@ namespace AlienFan_SDK {
 						// ESIF sensors
 						EnumSensors(m_WbemServices, L"EsifDeviceInformation", 0);
 						// SSD sensors
-						EnumSensors(m_DiskService, L"MSFT_PhysicalDiskToStorageReliabilityCounter", 2);
+						if (useDiskSensor)
+							EnumSensors(m_DiskService, L"MSFT_PhysicalDiskToStorageReliabilityCounter", 2);
 						// OHM sensors
 						if (m_OHMService) {
 							EnumSensors(m_OHMService, L"Sensor", 4);

--- a/alienfan-tools/alienfan-SDK_v2/alienfan-SDK.h
+++ b/alienfan-tools/alienfan-SDK_v2/alienfan-SDK.h
@@ -43,6 +43,7 @@ namespace AlienFan_SDK {
 		DWORD systemID = 0;
 		byte sysType = -1;
 		void EnumSensors(IWbemServices* srv, const wchar_t* sname, byte type);
+		bool useDiskSensor = true;
 	public:
 		VARIANT m_instancePath{};
 		IWbemServices* m_WbemServices = NULL, * m_OHMService = NULL, * m_DiskService = NULL;
@@ -117,6 +118,9 @@ namespace AlienFan_SDK {
 
 		// Set current XMP profile
 		int SetXMP(byte memXMP);
+
+		// Disable the query of the disk sensors to prevent freeze on some systems
+		void DisableDiskSensor() { useDiskSensor = false; };
 
 		// Return current device ID
 		inline DWORD GetSystemID() { return systemID; };

--- a/alienfan-tools/alienfan-cli/alienfan-cli.cpp
+++ b/alienfan-tools/alienfan-cli/alienfan-cli.cpp
@@ -132,7 +132,8 @@ gmode\t\t\t\tShow G-mode state\n\
 gettcc\t\t\t\tShow current TCC level\n\
 settcc=<level>\t\t\tSet TCC level\n\
 getxmp\t\t\t\tShow current memory XMP profile level\n\
-setxmp=<level>\t\t\tSet memory XMP profile level\n");
+setxmp=<level>\t\t\tSet memory XMP profile level\n\
+nodisksensor\t\t\tDo not query disk sensors (used to prevent alienfan-cli from freezing on some systems)\n");
 #ifndef NOLIGHTS
     printf("setcolor = id, r, g, b\t\tSet light to color\n\
 setbrightness=<brightness>\tSet lights brightness\n");
@@ -150,6 +151,13 @@ int main(int argc, char* argv[])
 #ifndef NOLIGHTS
     AlienFan_SDK::Lights* lights = NULL;
 #endif
+    // acpi.Probe and other calls to acpi will freeze on some systems that have faulty drivers.
+    // So we check the presence of "nodisksensor" option here before the first call to acpi is made
+    for (int cc = 1; cc < argc; cc++) {
+        string arg = argv[cc];
+        if (arg == "nodisksensor")
+            acpi.DisableDiskSensor();
+    }
     if (acpi.Probe()) {
 #ifndef NOLIGHTS
         lights = new AlienFan_SDK::Lights(&acpi);
@@ -316,6 +324,10 @@ int main(int argc, char* argv[])
                     printf("XMP switch locked");
                 continue;
             }
+
+            if (command == "nodisksensor")
+                continue;   // nodisksensor command already processed, ignore it at this point
+
             if (command == "dump" && acpi.isAlienware) { // dump WMI functions
                 BSTR name;
                 // Command dump


### PR DESCRIPTION
New `nodisksensor` command to prevent `alienfan-cli` from freezing on some systems.