### PR TITLE
Fix/memory resource safety

### DIFF
--- a/Common/Common.cpp
+++ b/Common/Common.cpp
@@ -1,6 +1,7 @@
 #include "Common.h"
 #include <windowsx.h>
 #include <WinInet.h>
+#include <memory>
 //#include <Psapi.h>
 
 using namespace std;
@@ -139,7 +140,8 @@ void ShowNotification(NOTIFYICONDATA* niData, string title, string message) {
 DWORD WINAPI CUpdateCheck(LPVOID lparam) {
 	NOTIFYICONDATA* niData = (NOTIFYICONDATA*)lparam;
 	HINTERNET session, req = NULL;
-	char* buf = new char[255];
+	// RAII so the buffer can't leak if std::string ops on `res` below ever throw bad_alloc.
+	unique_ptr<char[]> buf(new char[255]);
 	DWORD byteRead;
 	if (!needUpdateFeedback)
 		// check connection for some seconds
@@ -148,9 +150,9 @@ DWORD WINAPI CUpdateCheck(LPVOID lparam) {
 	if (InternetGetConnectedState(&byteRead, 0) && (session = InternetOpen("alienfx-tools", INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0))) {
 		if (req = InternetOpenUrl(session, "https://api.github.com/repos/t-troll/alienfx-tools/tags?per_page=1",
 			NULL, 0, INTERNET_FLAG_RELOAD | INTERNET_FLAG_NO_CACHE_WRITE, NULL)) {
-			if (InternetReadFile(req, buf, 254, &byteRead)) {
+			if (InternetReadFile(req, buf.get(), 254, &byteRead)) {
 				buf[byteRead] = 0;
-				string res = buf;
+				string res = buf.get();
 				size_t pos = res.find("\"name\":");
 				if (pos != string::npos) {
 					//isConnectionFailed = false;
@@ -177,7 +179,6 @@ DWORD WINAPI CUpdateCheck(LPVOID lparam) {
 	}
 	if (needUpdateFeedback && !req)
 			ShowNotification(niData, "Update check failed!", "Can't connect to GitHub for update check.");
-	delete[] buf;
 	needUpdateFeedback = false;
 	return 0;
 }

--- a/LightFX/LightFX.cpp
+++ b/LightFX/LightFX.cpp
@@ -174,6 +174,16 @@ FN_DECLSPEC LFX_RESULT STDCALL LFX_Initialize() {
 		stopQuery = CreateEvent(NULL, false, false, NULL);
 		haveNewElement = CreateEvent(NULL, false, false, NULL);
 		updateThread = CreateThread(NULL, 0, CLightsProc, NULL, 0, NULL);
+		if (!updateThread) {
+			// CreateThread failed: roll back the events we created so they don't
+			// leak, and free afx_dev so the next LFX_Initialize starts clean.
+			CloseHandle(stopQuery);
+			CloseHandle(haveNewElement);
+			stopQuery = haveNewElement = NULL;
+			delete afx_dev;
+			afx_dev = NULL;
+			return LFX_ERROR_NOINIT;
+		}
 		lightsNoDelay = true;
 	}
 	for (int g = 0; g < 4; g++)
@@ -202,8 +212,26 @@ FN_DECLSPEC LFX_RESULT STDCALL LFX_Initialize() {
 		}
 		return LFX_SUCCESS;
 	}
-	else
+	else {
+		// No devices found. CLightsProc (line 54) dereferences afx_dev WITHOUT a
+		// null check, so the worker thread MUST be stopped before afx_dev is freed,
+		// otherwise the next CLightsProc iteration crashes. We also release the
+		// thread+events so this NODEVS path doesn't leak resources to process exit
+		// when the caller (typically a game) decides "no Alienware hardware - give up".
+		if (updateThread) {
+			HANDLE oldUpdate = updateThread;
+			updateThread = NULL;
+			SetEvent(stopQuery);
+			WaitForSingleObject(oldUpdate, 20000);
+			CloseHandle(oldUpdate);
+			CloseHandle(stopQuery);
+			CloseHandle(haveNewElement);
+			stopQuery = haveNewElement = NULL;
+		}
+		delete afx_dev;
+		afx_dev = NULL;
 		return LFX_ERROR_NODEVS;
+	}
 }
 
 FN_DECLSPEC LFX_RESULT STDCALL LFX_Release() {

--- a/alienfx-gui/HapticsDialog.cpp
+++ b/alienfx-gui/HapticsDialog.cpp
@@ -84,7 +84,6 @@ void DrawFreq(HWND hysto) {
 		DeleteObject(hbmMem);
 		DeleteDC(hdc);
 		ReleaseDC(hysto, hdc_r);
-		DeleteDC(hdc_r);
 	}
 }
 

--- a/alienfx-gui/WSAudioIn.cpp
+++ b/alienfx-gui/WSAudioIn.cpp
@@ -2,6 +2,7 @@
 #include "ConfigHandler.h"
 #include "FXHelper.h"
 #include <math.h>
+#include <memory>
 
 #ifndef PI
 #define PI 3.141592653589793238462643383279502884197169399375
@@ -120,7 +121,7 @@ void WSAudioIn::Stop()
 
 IMMDevice* WSAudioIn::GetDefaultMultimediaDevice(EDataFlow DevType)
 {
-	IMMDeviceEnumerator* pEnumerator;
+	IMMDeviceEnumerator* pEnumerator = NULL;
 	IMMDevice* pDevice = NULL;
 
 	CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL, __uuidof(IMMDeviceEnumerator), (void**)&pEnumerator);
@@ -207,10 +208,14 @@ DWORD WINAPI FFTProc(LPVOID lpParam)
 	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
 
 	// Preparing FFT...
+	// RAII so any of the three array allocations throwing bad_alloc
+	// cannot leak the others, and kiss_cfg is checked for NULL.
+	std::unique_ptr<kiss_fft_scalar[]> padded_in(new kiss_fft_scalar[NUMPTS]);
+	std::unique_ptr<kiss_fft_cpx[]>    padded_out(new kiss_fft_cpx[NUMPTS]);
+	std::unique_ptr<double[]>          x2(new double[NUMPTS]);
 	void* kiss_cfg = kiss_fftr_alloc(NUMPTS, 0, 0, 0);
-	kiss_fft_scalar* padded_in = new kiss_fft_scalar[NUMPTS];
-	kiss_fft_cpx* padded_out = new kiss_fft_cpx[NUMPTS];
-	double* x2 = new double[NUMPTS];
+	if (!kiss_cfg)
+		return 0;
 	double peak = 0;
 
 	DWORD res;
@@ -221,7 +226,7 @@ DWORD WINAPI FFTProc(LPVOID lpParam)
 				padded_in[n] = (kiss_fft_scalar)(src->waveD[n] * src->blackman[n]);
 			}
 
-			kiss_fftr(kiss_cfg, padded_in, padded_out);
+			kiss_fftr(kiss_cfg, padded_in.get(), padded_out.get());
 
 			double minP = INT_MAX, maxP = 0;
 			double mult = 1.3394/* sqrt3(2)*/, f = 1.0;
@@ -263,9 +268,6 @@ DWORD WINAPI FFTProc(LPVOID lpParam)
 			fxhl->RefreshHaptics();
 		}
 	}
-	delete[] padded_in;
-	delete[] padded_out;
 	kiss_fft_free(kiss_cfg);
-	delete[] x2;
 	return 0;
 }


### PR DESCRIPTION
## Summary

A set of memory- and resource-safety fixes across four files. No behavioural change on the success path; each change closes a leak, a use-after-free risk, or an uninitialized read on a failure/exception path.

## Changes

### `Common/Common.cpp` — Update check buffer exception safety
The 255-byte `char` buffer used by `CUpdateCheck` was allocated with raw `new[]` and freed only after several `std::string` operations that can throw `bad_alloc` on OOM. Switched to `std::unique_ptr<char[]>` so the buffer cannot leak on the exception path. The 254-byte GitHub-API read through the same WinINet handles is unchanged.

### `LightFX/LightFX.cpp` — Init resource cleanup on failure paths
Two fixes in `LFX_Initialize`:

- **`NODEVS` path:** when no devices are detected, the previous code returned `LFX_ERROR_NODEVS` leaving the worker thread, its two events, and `afx_dev` allocated for process lifetime. Now the `NODEVS` branch stops the worker (`SetEvent` + `WaitForSingleObject` + `CloseHandle` on the thread and both events) and then deletes `afx_dev`. `CLightsProc` at `LightFX.cpp:54` dereferences `afx_dev` with no NULL guard, so the thread is stopped **before** `afx_dev` is freed, and a comment documents the invariant so future cleanup passes do not reorder it into a use-after-free.
- **`CreateThread` failure path:** if `CreateThread` in the same block returned `NULL`, the two `CreateEvent` handles created moments earlier leaked and `afx_dev` was left orphaned. The new `if (!updateThread)` branch closes both events, NULLs them, frees `afx_dev`, and returns `LFX_ERROR_NOINIT`.

### `alienfx-gui/HapticsDialog.cpp` — Drop redundant `DeleteDC`
`DrawFreq()` already returns the window DC via `ReleaseDC(hysto, hdc_r)`, so the following `DeleteDC(hdc_r)` was a no-op on an already-released handle (`DeleteDC` is for `CreateCompatibleDC` results, not `GetDC` results). Removed the redundant line.

### `alienfx-gui/WSAudioIn.cpp` — Initialize COM enumerator, RAII FFT buffers
Two fixes:

- `GetDefaultMultimediaDevice()` declared `IMMDeviceEnumerator* pEnumerator` uninitialized, then tested it with `if (pEnumerator)` after `CoCreateInstance`. If `CoCreateInstance` failed, the out-param was not guaranteed `NULL` and the check read indeterminate stack memory. Now initialized to `NULL`.
- `FFTProc()` allocated `kiss_cfg` + three `new[]` arrays without rollback; a `bad_alloc` in any later allocation leaked the earlier ones, and `kiss_fftr_alloc` returning `NULL` caused a `NULL` dereference in `kiss_fftr` below. Switched the three arrays to `std::unique_ptr<T[]>`, moved `kiss_fftr_alloc` after them, and added a `NULL` check that returns early. Updated the `kiss_fftr` call site to use `.get()`. Removed the three matching `delete[]` lines at function exit; `kiss_fft_free` is retained.

## Notes
- No public API or success-path behaviour changes.
- Resource lifetimes are now exception-safe where they were not before.
